### PR TITLE
feat: 소셜 로그인 관련 api #1

### DIFF
--- a/common/src/main/java/com/letter/member/OAuthController.java
+++ b/common/src/main/java/com/letter/member/OAuthController.java
@@ -1,0 +1,29 @@
+package com.letter.member;
+
+import com.letter.member.dto.OAuthResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final MemberService memberService;
+    private final OAuthService oAuthService;
+
+    /**
+     * 카카오에서 access token 가져오기
+     * 가져온 access token 으로 카카오 사용자 정보 조회
+     * 닉네임과 이메일을 가져와서 dto에 담기
+     * 디비에 회원 정보가 있을 경우 그냥 access token 발급, 없을 경우 디비에 회원 정보 저장 후 access token 발급하기
+     * @param code
+     * @return
+     */
+    @PostMapping("/kakao/callback")
+    public OAuthResponse kakaoCallback(@RequestParam(name = "code") String code){ // 쿼리 스트링으로 들어오니까 @RequestParam 붙이기
+        System.out.println("성공적으로 카카오 로그인 API 인가 코드를 불러왔습니다." + "code는 " + code);
+        return oAuthService.getOAuthInfo(code);
+    }
+
+}

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -1,0 +1,15 @@
+package com.letter.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+
+//    public String login() {
+//        List<Member> allByMemberId = memberRepository.findAllByMemberId("123");
+//        return allByMemberId.size() == 0 ? "login" : "no";
+//    }
+}

--- a/domain/src/main/java/com/letter/member/OAuthService.java
+++ b/domain/src/main/java/com/letter/member/OAuthService.java
@@ -1,0 +1,191 @@
+package com.letter.member;
+
+//import com.fasterxml.jackson.databind.JsonNode;
+import com.google.gson.JsonElement;
+import com.letter.jwt.JwtProperties;
+import com.letter.member.dto.OAuthResponse;
+import com.letter.member.entity.Member;
+import com.letter.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.google.gson.JsonParser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Optional;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 카카오 사용자 회원정보 담긴 것 가져오기
+     * 회원 정보가 디비에 없으면 저장하고 있으면 바로 access token 발급
+     * @param code
+     * @return
+     */
+    @Transactional
+    public OAuthResponse getOAuthInfo(String code){
+        // dto에 담은 사용자 정보 가져오기
+        OAuthResponse userInfo = getKakaoUserInfo(code);
+        // 이메일과 미디어 구분으로 디비에 해당 회원 정보가 있는지 조회
+        Optional<Member> member = memberRepository.findByAndEmailAndMediaSeparator(userInfo.getEmail(), "kakao");
+
+        // 회원 정보가 있으면 디비에 저장없이 토큰 발급
+        // 회원 정보가 없으면 정보를 디비에 저장하고 토큰 발급
+        if(member.isEmpty()){
+            // 총 회원 수 + 1
+            Long memberCount = memberRepository.countAllBy() + 1;
+            //디비에 회원 정보 저장(회원 아이디,이메일,이름,미디어 구분 값,리프레쉬 토큰)
+            // Member 엔티티에 값 셋팅
+            Member member1 = new Member();
+            member1.saveUserInfo(userInfo, memberCount);
+            // 디비에 저장
+            memberRepository.save(member1);
+        }
+        // access token 발급
+
+        return userInfo;
+    }
+
+
+    /**
+     * 카카오에서 access token 가져오기
+     * @param code
+     * @return
+     */
+    public String getKakaoAccessToken (String code) {
+        String access_Token = "";
+        String reqURL = "https://kauth.kakao.com/oauth/token";
+
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            //POST 요청을 위해 기본값이 false인 setDoOutput을 true로
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+
+            //POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+            StringBuilder sb = new StringBuilder();
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=8a4726cfed8673405f24582af1d2ff15"); // REST_API_KEY 입력
+            sb.append("&redirect_uri=http://localhost:8080/api/v1/members/kakao/callback"); // 인가코드 받은 redirect_uri 입력
+            sb.append("&code=" + code);
+            bw.write(sb.toString());
+            bw.flush();
+
+            //결과 코드가 200이라면 성공
+            int responseCode = conn.getResponseCode();
+            System.out.println("responseCode : " + responseCode);
+
+            //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("response body : " + result);
+
+            //Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            access_Token = element.getAsJsonObject().get("access_token").getAsString();
+
+            System.out.println("access_token : " + access_Token);
+
+            br.close();
+            bw.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return access_Token;
+
+    }
+
+    /**
+     * 카카오에서 가져온 access token으로 사용자 정보 조회 후 dto에 담기
+     * @param code
+     * @return
+     */
+    public OAuthResponse getKakaoUserInfo(String code){
+
+        // 카카오에서 access token 가져오기
+        String accessToken = getKakaoAccessToken(code);
+
+
+        String reqURL = "https://kapi.kakao.com/v2/user/me"; // 카카오에서 정보를 가져오기 위한 url
+        String email = "";
+        String nickname = "";
+        //access_token을 이용하여 사용자 정보 조회
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken); //전송할 header 작성, access_token전송
+
+            //결과 코드가 200이라면 성공
+            int responseCode = conn.getResponseCode();
+            System.out.println("responseCode : " + responseCode);
+
+            //요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("response body : " + result);
+
+            //Gson 라이브러리로 JSON파싱
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            // 이메일이 있는지 여부
+            boolean hasEmail = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("has_email").getAsBoolean();
+            // "kakao_account" 객체 안에 "profile" 객체 안에 nickname 가져오기
+            nickname = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("profile").getAsJsonObject().get("nickname").getAsString();
+
+            // 이메일이 있을 경우만 가져오기
+            if(hasEmail){
+                // "kakao_account" 객체 안에 email 가져오기
+                email = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email").getAsString();
+            }
+
+            System.out.println("nickname : " + nickname);
+            System.out.println("email : " + email);
+
+            br.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return OAuthResponse.builder()
+                .nickname(nickname)
+                .email(email)
+                .build();
+    }
+
+}
+
+
+
+
+

--- a/storage/src/main/java/com/letter/member/dto/OAuthResponse.java
+++ b/storage/src/main/java/com/letter/member/dto/OAuthResponse.java
@@ -1,0 +1,16 @@
+package com.letter.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Builder
+@Data
+@AllArgsConstructor
+public class OAuthResponse {
+    private String nickname;
+    private String email;
+
+}

--- a/storage/src/main/java/com/letter/member/entity/Member.java
+++ b/storage/src/main/java/com/letter/member/entity/Member.java
@@ -1,21 +1,28 @@
 package com.letter.member.entity;
 
+import com.letter.member.dto.OAuthResponse;
 import com.letter.question.entity.Answer;
 import com.letter.question.entity.RegisterQuestion;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @Entity
 @Table(name = "YI_MEMBER", schema = "YI")
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
@@ -64,5 +71,34 @@ public class Member {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<RegisterQuestion> registerQuestions = new ArrayList<>();
+
+    /**
+     * 디비에 저장 할 값 셋팅
+     * @param userInfo
+     * @param memberCount
+     */
+    public void saveUserInfo(OAuthResponse userInfo, Long memberCount) {
+        // 생성한 회원 아이디
+        createMemberId(memberCount);
+        // 값 셋팅
+        this.name = userInfo.getNickname();
+        this.email = userInfo.getEmail();
+
+        // TODO 임시 값 변경
+        this.mediaSeparator = "kakao";
+        this.refreshToken = "token";
+
+    }
+
+    /**
+     * 회원 아이디 생성(등록날짜+총 회원 수 마지막 + 1, 총 13자리)
+     * @param memberCount
+     */
+    private void createMemberId(Long memberCount) {
+        // 등록 일시 포맷 변경(예:20231212)
+        String prefix = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        // 회원 아이디 생성
+        this.id = prefix.concat(String.format("%05d", memberCount));
+    }
 
 }

--- a/storage/src/main/java/com/letter/member/repository/MemberRepository.java
+++ b/storage/src/main/java/com/letter/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.letter.member.repository;
+
+import com.letter.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member,String> {
+
+    // 이메일과 미디어 구분 값으로 디비에 있는 회원 정보 조회
+    Optional<Member> findByAndEmailAndMediaSeparator(String email, String media);
+
+    // 총 회원 수 카운트
+    long countAllBy();
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#1

## 📝작업 내용

- 카카오에서 access token 가져오기
- 가져온 access token 으로 카카오 사용자 정보 조회
- 닉네임과 이메일을 가져와서 dto에 담기
- 디비에 해당 회원의 정보가 없으면 회원 정보 저장하기
