### PR TITLE
Feat/auth: 상대 초대 링크 생성 api

### DIFF
--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -1,0 +1,35 @@
+package com.letter.member;
+
+import com.letter.member.dto.MemberRequest;
+import com.letter.member.dto.MemberResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "OAuth", description = "상대 초대 관련 API")
+@RestController
+@RequestMapping("/api/v1/members/invite")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+
+
+    @Operation(summary = "상대 초대 링크 API")
+    @ApiResponses(value ={
+            @ApiResponse(responseCode= "200",description = "토큰 발급 성공")
+    })
+    @PostMapping("/link")
+    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request){
+
+        // TODO: 회원 인증
+        return ResponseEntity.ok().body(memberService.createInviteLink(request));
+    }
+
+}

--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -27,7 +27,7 @@ public class MemberController {
             @ApiResponse(responseCode= "201",description = "초대 링크 키 생성 완료")
     })
     @PostMapping("/link")
-    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.ReqCreateInviteLink request){
+    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request){
         // TODO: 사용자 인증
 
         return ResponseEntity.ok().body(memberService.createInviteLink(request));

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -1,15 +1,51 @@
 package com.letter.member;
 
+import com.letter.member.dto.MemberRequest;
+import com.letter.member.dto.MemberResponse;
+import com.letter.member.entity.InviteOpponent;
+import com.letter.member.entity.Member;
+import com.letter.member.repository.InviteOpponentRepository;
+import com.letter.member.repository.MemberRepository;
+import com.letter.question.entity.Question;
+import com.letter.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final QuestionRepository questionRepository;
+    private final MemberRepository memberRepository;
+    private final InviteOpponentRepository inviteOpponentRepository;
 
-//    public String login() {
-//        List<Member> allByMemberId = memberRepository.findAllByMemberId("123");
-//        return allByMemberId.size() == 0 ? "login" : "no";
-//    }
+    public MemberResponse.CreateInviteLinkResponse createInviteLink(MemberRequest.CreateInviteLinkRequest request) {
+        // 링크 고유 키 생성
+        String uuid = UUID.randomUUID().toString();
+
+        // 질문 아이디 조회
+        Question question = questionRepository.findQuestionById(request.getQuestionId()).orElseThrow(
+                () -> new RuntimeException(HttpStatus.BAD_REQUEST.name()));
+
+        // TODO: 토큰에서 회원 아이디 가져와서 셋팅하기
+        // 회원 아이디 조회
+        Member member = memberRepository.findById("2023121200002").orElseThrow(
+                () -> new RuntimeException(HttpStatus.UNAUTHORIZED.name())
+        );
+
+        // 상대 초대 테이블에 정보 request 셋팅
+        InviteOpponent inviteOpponent = request.toCreateInviteLink(uuid,question,member);
+
+        // 상대 초대 테이블에 정보 등록
+        inviteOpponentRepository.save(inviteOpponent);
+
+        return MemberResponse.CreateInviteLinkResponse.builder()
+                .linkKey(uuid)
+                .question(question.getQuestionContents())
+                .build();
+
+    }
 }

--- a/storage/src/main/java/com/letter/member/dto/MemberRequest.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberRequest.java
@@ -1,0 +1,32 @@
+package com.letter.member.dto;
+
+import com.letter.member.entity.InviteOpponent;
+import com.letter.member.entity.Member;
+import com.letter.question.entity.Question;
+import lombok.*;
+
+
+@Data
+public class MemberRequest {
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    public static class CreateInviteLinkRequest{
+
+        private Long questionId;
+        private String answer;
+
+        public InviteOpponent toCreateInviteLink(String uuid, Question question, Member member) {
+            return InviteOpponent.builder()
+                    .question(question)
+                    .member(member)
+                    .answer(answer)
+                    .linkKey(uuid)
+                    .build();
+        }
+    }
+
+
+}

--- a/storage/src/main/java/com/letter/member/dto/MemberResponse.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberResponse.java
@@ -1,0 +1,19 @@
+package com.letter.member.dto;
+
+import lombok.*;
+
+@RequiredArgsConstructor
+@Data
+public class MemberResponse {
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    public static class CreateInviteLinkResponse{
+        private String linkKey;
+        private String question;
+    }
+
+
+}

--- a/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
+++ b/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
@@ -4,13 +4,21 @@ import com.letter.question.entity.Question;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "YI_INVITE_OPPONENT", schema = "YI")
 public class InviteOpponent {
     @Id

--- a/storage/src/main/java/com/letter/member/repository/InviteOpponentRepository.java
+++ b/storage/src/main/java/com/letter/member/repository/InviteOpponentRepository.java
@@ -1,0 +1,11 @@
+package com.letter.member.repository;
+
+import com.letter.member.entity.InviteOpponent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface InviteOpponentRepository extends JpaRepository<InviteOpponent,Long> {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#13 

## 📝작업 내용


- 질문 아이디랑 답변을 request로 받는다.
- 링크 고유 키를 생성한다.
- 상대 초대 테이블에 해당 데이터들 등록
- response로 질문,링크 고유 값 내려주기
