### PR TITLE
fix: cors 에러 해결 및 클라이언트에서 헤더에 접근허용 설정 추가 #42

### DIFF
--- a/common/src/main/java/com/letter/config/WebConfig.java
+++ b/common/src/main/java/com/letter/config/WebConfig.java
@@ -10,10 +10,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry){
         corsRegistry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("Authorization", "Content-Type")
-                .exposedHeaders("Custom-Header")
+                .exposedHeaders("Custom-Header","Authorization") // 나가는 헤더 설정
+                .allowedHeaders("Access-Control-Request-Headers") // 클라이언트에서 헤더에서 접근 가능하게 하기 위한 설정
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/common/src/main/java/com/letter/member/OAuthController.java
+++ b/common/src/main/java/com/letter/member/OAuthController.java
@@ -32,7 +32,7 @@ public class OAuthController {
     @ApiResponses(value ={
             @ApiResponse(responseCode= "200",description = "토큰 발급 성공")
     })
-    @PostMapping("/kakao/callback")
+    @GetMapping("/kakao/callback")
     public ResponseEntity<String> kakaoCallback(@RequestParam(name = "code") String code){ // 쿼리 스트링으로 들어오니까 @RequestParam 붙이기
         System.out.println("성공적으로 카카오 로그인 API 인가 코드를 불러왔습니다." + "code는 " + code);
         return oAuthService.getOAuthInfo(code);


### PR DESCRIPTION
## #️⃣연관된 이슈
#42 

## 📝작업 내용
- 프론트에서 로그인 api 연동 작업중에 cors 에러가 발생 + 클라이언트에서 헤더에 접근 허용을 위해 WebConfig 파일에 설정 추가
