### PR TITLE
Feat/auth: jwt 관련 로직 jwtProvider 파일로 분리 및 로그인 확인 커스텀 어노테이션 생성

### DIFF
--- a/common/src/main/java/com/letter/annotation/LoginCheck.java
+++ b/common/src/main/java/com/letter/annotation/LoginCheck.java
@@ -1,0 +1,10 @@
+package com.letter.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface LoginCheck {
+}

--- a/common/src/main/java/com/letter/config/WebConfig.java
+++ b/common/src/main/java/com/letter/config/WebConfig.java
@@ -1,21 +1,42 @@
 package com.letter.config;
 
+import com.letter.interceptor.LoginCheckInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginCheckInterceptor loginCheckInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry){
         corsRegistry.addMapping("/**")
                 .allowedOriginPatterns("*")
-                .allowedMethods("GET", "POST", "PUT", "DELETE")
-                .allowedHeaders("Authorization", "Content-Type")
+//                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedMethods("*")
+                .allowedHeaders("*")
                 .exposedHeaders("Custom-Header","Authorization") // 나가는 헤더 설정
-                .allowedHeaders("Access-Control-Request-Headers") // 클라이언트에서 헤더에서 접근 가능하게 하기 위한 설정
+//                .allowedHeaders("Access-Control-Request-Headers") // 클라이언트에서 헤더에서 접근 가능하게 하기 위한 설정
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    /**
+     * Controller method를 실행하기 전에 LoginCheckInterceptor를 실행하게 된다.
+     * @param registry
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginCheckInterceptor)
+                .addPathPatterns("/**") // 모든 패턴 가능
+                .excludePathPatterns("/swagger-ui/index.html") // 스웨거 쪽 제외
+                .excludePathPatterns("/api-docs") // 스웨거 쪽 제외
+                .excludePathPatterns("/api/v1/members/kakao/callback"); // 로그인 제외
+
     }
 }

--- a/common/src/main/java/com/letter/interceptor/LoginCheckInterceptor.java
+++ b/common/src/main/java/com/letter/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,48 @@
+package com.letter.interceptor;
+
+import com.letter.annotation.LoginCheck;
+import static com.letter.jwt.JwtProperties.*;
+import com.letter.jwt.JwtProvider;
+import com.letter.member.entity.Member;
+import com.letter.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.naming.AuthenticationException;
+import java.util.Optional;
+
+@Configuration
+@RequiredArgsConstructor
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        // HandlerMethod 을 상속받은 클래스가 아닌 경우 인터셉터 로직을 실행시키지 않도록 바로 true 를 반환하여 통과시켜 줌
+        if(!(handler instanceof HandlerMethod)) return true;
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        if (request.getRequestURI().contains("/api")&& handler instanceof HandlerMethod) {
+
+            String token = jwtProvider.bringToken(request);
+            jwtProvider.validateToken(token, SECRET);
+            String memberId = jwtProvider.getUserInfoFromToken(token, SECRET);
+            final Optional<Member> member = memberRepository.findById(memberId);
+
+            if (handlerMethod.hasMethodAnnotation(LoginCheck.class) && member.isEmpty()) { //실행하고자 하는 Controller method의 어노테이션 중 LoginCheck가 있는지 체크
+                // 회원 아이디가 비어있으면 로그인 되어있지 않은 상태이므로 예외를 발생시킵니다.
+                throw new AuthenticationException(request.getRequestURI());
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -1,5 +1,6 @@
 package com.letter.member;
 
+import com.letter.annotation.LoginCheck;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,7 @@ public class MemberController {
     @ApiResponses(value ={
             @ApiResponse(responseCode= "201",description = "초대 링크 키 생성 완료")
     })
+    @LoginCheck
     @PostMapping("/link")
     public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request){
         // TODO: 사용자 인증
@@ -34,6 +36,7 @@ public class MemberController {
     @ApiResponses(value ={
             @ApiResponse(responseCode= "201",description = "초대 수락 완료")
     })
+    @LoginCheck
     @PostMapping("/accept")
     public ResponseEntity<MemberResponse.AcceptInviteLinkResponse> acceptedInvite(@RequestBody @Valid MemberRequest.AcceptInviteLinkRequest request){
         // TODO: 사용자 인증
@@ -45,6 +48,7 @@ public class MemberController {
     @ApiResponses(value ={
             @ApiResponse(responseCode= "200",description = "정보 가져오기 완료")
     })
+    @LoginCheck
     @GetMapping ("/info")
     public ResponseEntity<MemberResponse.InvitedPersonInfoResponse> getInvitedPersonInfo(@Valid MemberRequest.InvitedPersonInfoRequest request){
         // TODO: 사용자 인증

--- a/domain/src/main/java/com/letter/jwt/JwtProperties.java
+++ b/domain/src/main/java/com/letter/jwt/JwtProperties.java
@@ -1,6 +1,9 @@
 package com.letter.jwt;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
 public interface JwtProperties{
     String SECRET = ""; // 해싱 메시지 암호화 한 것 넣기
     long EXPIRATION_TIME =  30 * 60 * 1000L; // 유효시간은 30분

--- a/domain/src/main/java/com/letter/jwt/JwtProvider.java
+++ b/domain/src/main/java/com/letter/jwt/JwtProvider.java
@@ -1,0 +1,122 @@
+package com.letter.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.letter.exception.CustomException;
+import com.letter.exception.ErrorCode;
+import com.letter.member.dto.OAuthResponse;
+import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtProvider {
+
+    private static final Long refreshTokenValidTime = Duration.ofDays(14).toMillis(); // 만료시간 2주
+
+    /**
+     * jwt 토큰 생성하기
+     * @param userInfo
+     * @return
+     */
+    public String createJwtToken(String memberId, OAuthResponse userInfo) {
+
+        String jwtToken = JWT.create()
+                .withSubject(memberId) // Payload 에 들어갈 등록된 클레임 을 설정한다.
+                .withExpiresAt(new Date(System.currentTimeMillis()+ JwtProperties.EXPIRATION_TIME)) //JwtProperties 의 만료 시간 필드를 불러와 넣어준다.
+                .withClaim("nickname", userInfo.getNickname()) // Payload 에 들어갈 개인 클레임 을 설정한다.
+                // .withClaim(이름, 내용) 형태로 작성한다. 사용자를 식별할 수 있는 값과, 따로 추가하고 싶은 값을 자유롭게 넣는다.
+                .sign(Algorithm.HMAC512(JwtProperties.SECRET)); // 사용할 암호화 알고리즘과 secret 값 셋팅
+        return jwtToken;
+    }
+
+    /**
+     * 헤더에서 토큰 가져오기
+     * @param request
+     * @return
+     */
+    public String bringToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(JwtProperties.HEADER_STRING);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(JwtProperties.TOKEN_PREFIX)) {
+            return bearerToken.substring(7); // "Bearer " 을 제외한 토큰만 가져오기
+        }
+        return null;
+    }
+
+    /**
+     * 토큰 검증
+     * @param token
+     * @return
+     */
+    public boolean validateToken(String token, String secretKey) {
+
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token, 만료된 JWT token 입니다.");
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+            throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims is empty, 잘못된 JWT 토큰 입니다. 토큰이 비었을 수 있으니 다시 확인해주세요.");
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 정보 가져오기
+     * @param token
+     * @return
+     */
+    public String getUserInfoFromToken(String token, String secretKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("sub", String.class);
+    }
+
+//    /**
+//     * refresh 토큰 확인
+//     * @param token
+//     * @param secretKey
+//     * @return
+//     */
+//    public static boolean isRefreshToken(String token, String secretKey) {
+//
+//        Header header = Jwts.parser()
+//                .setSigningKey(secretKey)
+//                .parseClaimsJws(token)
+//                .getHeader();
+//
+//        if (header.get("type").toString().equals("refresh")) {
+//            return true;
+//        }
+//        return false;
+//    }
+
+//    /**
+//     * refresh 토큰 생성
+//     * @param memberId
+//     * @param userInfo
+//     * @return
+//     */
+//    public static String createRefreshToken(String memberId, OAuthResponse userInfo) {
+//        return createJwtToken(memberId, userInfo);
+//    }
+
+}

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.letter.member;
 
+import com.letter.jwt.JwtProvider;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
 import com.letter.member.entity.Couple;
@@ -33,6 +34,8 @@ public class MemberService {
     private final InviteOpponentRepository inviteOpponentRepository;
     private final AnswerRepository answerRepository;
     private final SelectQuestionRepository selectQuestionRepository;
+
+    private final JwtProvider jwtProvider;
 
 
     /**
@@ -76,6 +79,7 @@ public class MemberService {
      * @return
      */
     public MemberResponse.AcceptInviteLinkResponse acceptedInvite(MemberRequest.AcceptInviteLinkRequest request) {
+
 
         // TODO: 토큰에서 회원 아이디 가져와서 셋팅하기
         // 회원 아이디 조회

--- a/storage/src/main/java/com/letter/exception/ErrorCode.java
+++ b/storage/src/main/java/com/letter/exception/ErrorCode.java
@@ -15,7 +15,14 @@ public enum ErrorCode {
 
     /* 409 */
     ALREADY_SELECTED_QUESTION(HttpStatus.CONFLICT, "이미 선택했던 질문입니다."),
-    ALREADY_ANSWER(HttpStatus.CONFLICT, "질문에 이미 답변을 작성했습니다.");
+    ALREADY_ANSWER(HttpStatus.CONFLICT, "질문에 이미 답변을 작성했습니다."),
+
+    /* 401 */
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED,"잘못된 JWT 토큰 입니다. 토큰이 비어있을 수 있으니 확인해주세요."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 JWT token 입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않는 JWT 서명 입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"지원되지 않는 JWT 토큰 입니다.");
+
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈
#57 

## 📝작업 내용

- OAuthService 에 jwt 관련 코드를 JwtProvider 파일로 분리
- jwtProvider 파일에 헤더에서 토큰 가져오기,토큰 검증, 토큰에서 사용자 정보 가져오는 함수 추가
--- 
- 만들 어노테이션 이름으로 인터페이스 생성
- 인터셉터 파일 생성
- WebConfig에 해당 인터셉터 등록
- 관련 api Controller에 해당 어노테이션 추가
- cors 에러 해결을 위해 WebConfing 에 allowedMethods 와일드 카드로 변경
- 인터셉터에 HandlerMethod 을 상속받은 클래스가 아닌 경우 인터셉터 로직을 실행시키지 않도록 바로 true 를 반환하는 로직 추가
