### PR TITLE
fix: Dockerfile 수정

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:17-jdk
+FROM adoptopenjdk:17-jdk-hotspot
 
 ARG JAR_FILE=common/build/libs/*.jar
 


### PR DESCRIPTION
## 📝작업 내용

- `Build, Tag, and Push Image to Amazon ECR`에서 `failed to solve: adoptopenjdk:17-jdk: docker.io/library/adoptopenjdk:17-jdk: not found`에러 발생
- Dockerfile에서 baseImage 버전 수정