### PR TITLE
fix: Dockerfile 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'zulu'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:17-jdk-hotspot
+FROM azul/zulu-openjdk:17
 
 ARG JAR_FILE=common/build/libs/*.jar
 


### PR DESCRIPTION
## 📝작업 내용

- `Build, Tag, and Push Image to Amazon ECR`에서 `failed to solve: adoptopenjdk:17-jdk: docker.io/library/adoptopenjdk:17-jdk: not found`에러 발생
- `adoptopenjdk:17-jdk-hotspot`도 `adoptopenjdk:17-jdk`도 존재하지 않음
- Dockerfile에서 baseImage 버전 수정
