### PR TITLE
fix: Dockerfile 수정

### DIFF
--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,6 +1,6 @@
 FROM azul/zulu-openjdk:17
 
-ARG JAR_FILE=common/build/libs/*.jar
+ARG JAR_FILE=/build/libs/*.jar
 
 COPY ${JAR_FILE} common.jar
 


### PR DESCRIPTION
## 📝작업 내용

- `Build, Tag, and Push Image to Amazon ECR`에서 `failed to solve: lstat /var/lib/docker/tmp/buildkit-mount1003300474/common/build/libs: no such file or directory`에러 발생
- Dockerfile에서 JAR_FILE ARG 경로 수정