### PR TITLE
사용자 조회 커스텀 어노테이션 추가 + 로그인 api  로직 수정 + 초대 관련 api 에 커스텀 어노테이션 적용 및 초대 수락 api 로직 수정

### DIFF
--- a/common/src/main/java/com/letter/annotation/User.java
+++ b/common/src/main/java/com/letter/annotation/User.java
@@ -1,0 +1,8 @@
+package com.letter.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface User {
+}

--- a/common/src/main/java/com/letter/config/WebConfig.java
+++ b/common/src/main/java/com/letter/config/WebConfig.java
@@ -1,17 +1,23 @@
 package com.letter.config;
 
 import com.letter.interceptor.LoginCheckInterceptor;
+//import com.letter.interceptor.LoginUserArgumentResolver;
+import com.letter.interceptor.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginCheckInterceptor loginCheckInterceptor;
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry){
@@ -38,5 +44,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/api-docs") // 스웨거 쪽 제외
                 .excludePathPatterns("/api/v1/members/kakao/callback"); // 로그인 제외
 
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+        resolvers.add(loginUserArgumentResolver);
     }
 }

--- a/common/src/main/java/com/letter/interceptor/LoginUserArgumentResolver.java
+++ b/common/src/main/java/com/letter/interceptor/LoginUserArgumentResolver.java
@@ -1,0 +1,62 @@
+package com.letter.interceptor;
+
+import com.letter.annotation.User;
+import com.letter.exception.CustomException;
+import com.letter.exception.ErrorCode;
+import com.letter.jwt.JwtProvider;
+import com.letter.member.entity.Member;
+import com.letter.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Optional;
+
+import static com.letter.jwt.JwtProperties.SECRET;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 현재 parameter를 resolver가 지원할지 true/false로 반환한다.
+     * 해당 메서드가 참이라면 resolveArgument()를 반환한다.
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // hasParameterAnnotation()을 사용하여 @User 어노테이션이 있는지 확인
+        return parameter.hasParameterAnnotation(User.class);
+    }
+
+    /**
+     * 실제 바인딩할 객체를 반환한다.
+     */
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception       {
+
+        String token = webRequest.getHeader("Authorization").substring(7);
+        log.info("토큰 확인!! {}",token);
+
+        jwtProvider.validateToken(token, SECRET);
+        String memberId = jwtProvider.getUserInfoFromToken(token, SECRET);
+        final Optional<Member> member = memberRepository.findById(memberId);
+        if(member.isEmpty()){
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        log.info("회원 아이디: {}",memberId);
+
+        return member.orElseThrow();
+    }
+}

--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -1,8 +1,10 @@
 package com.letter.member;
 
 import com.letter.annotation.LoginCheck;
+import com.letter.annotation.User;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
+import com.letter.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -28,9 +30,9 @@ public class MemberController {
     })
     @LoginCheck
     @PostMapping("/link")
-    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request){
+    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request, @User Member member){
 
-        return ResponseEntity.ok().body(memberService.createInviteLink(request));
+        return ResponseEntity.ok().body(memberService.createInviteLink(request,member));
     }
 
     @Operation(summary = "초대 수락 API")
@@ -39,9 +41,9 @@ public class MemberController {
     })
     @LoginCheck
     @PostMapping("/accept")
-    public ResponseEntity<MemberResponse.AcceptInviteLinkResponse> acceptedInvite(@RequestBody @Valid MemberRequest.AcceptInviteLinkRequest request){
+    public ResponseEntity<MemberResponse.AcceptInviteLinkResponse> acceptedInvite(@RequestBody @Valid MemberRequest.AcceptInviteLinkRequest request, @User Member member){
 
-        return ResponseEntity.ok().body(memberService.acceptedInvite(request));
+        return ResponseEntity.ok().body(memberService.acceptedInvite(request,member));
     }
 
     @Operation(summary = "초대 링크로 랜딩되는 페이지 API")

--- a/storage/src/main/java/com/letter/exception/ErrorCode.java
+++ b/storage/src/main/java/com/letter/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     COUPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "커플로 등록되지 않은 사용자입니다."),
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "프리셋에 존재하지 않는 질문입니다."),
     SELECT_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "선택 질문을 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"찾는 회원 아이디가 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND,"찾으시는 결과가 없습니다."),
 
     /* 409 */
     ALREADY_SELECTED_QUESTION(HttpStatus.CONFLICT, "이미 선택했던 질문입니다."),
@@ -24,7 +26,8 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED,"지원되지 않는 JWT 토큰 입니다."),
 
     /* 400 */
-    BAD_REQUEST(HttpStatus.BAD_REQUEST,"잘못된 요청값 입니다. 다시 확인해주새요.");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,"잘못된 요청값 입니다. 다시 확인해주새요."),
+    MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST,"초대한 사람의 아이디와 초대된 사람의 아이디가 같습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/storage/src/main/java/com/letter/member/dto/MemberRequest.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberRequest.java
@@ -58,6 +58,7 @@ public class MemberRequest {
         public Answer toAnswerInfo(Member member, SelectQuestion selectQuestion, String answer) {
             return Answer.builder()
                     .member(member)
+                    .couple(selectQuestion.getCouple())
                     .selectQuestion(selectQuestion)
                     .answerContents(answer)
                     .isShow("Y")

--- a/storage/src/main/java/com/letter/member/dto/MemberResponse.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberResponse.java
@@ -43,7 +43,7 @@ public class MemberResponse {
             @ApiResponse(description = "초대 링크로 랜딩되는 페이지 관련 response")
     })
     public static class InvitedPersonInfoResponse{
-        private Long selectedQuestionId;
+        private String question;
         private String invitedPersonName;
     }
 

--- a/storage/src/main/java/com/letter/member/dto/OAuthResponse.java
+++ b/storage/src/main/java/com/letter/member/dto/OAuthResponse.java
@@ -12,6 +12,6 @@ import lombok.RequiredArgsConstructor;
 public class OAuthResponse {
     private String nickname;
     private String email;
-    private String jwtToken;
+    private Long id;
 
 }

--- a/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
+++ b/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -45,6 +46,11 @@ public class InviteOpponent {
     @NotNull
     @Column(name = "ANS", nullable = false, length = 1000)
     private String answer;
+
+    @Size(max = 1)
+    @ColumnDefault("Y")
+    @Column(name = "IS_SHOW", length = 1)
+    private String isShow;
 
     @CreatedDate
     @NotNull

--- a/storage/src/main/java/com/letter/member/entity/Member.java
+++ b/storage/src/main/java/com/letter/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.letter.member.dto.OAuthResponse;
 import com.letter.question.entity.Answer;
 import com.letter.question.entity.RegisterQuestion;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -29,6 +30,10 @@ public class Member {
     @Size(max = 30)
     @Column(name = "MBR_ID", nullable = false, length = 30)
     private String id;
+
+    @Min(value = 0)
+    @Column(name = "KAKAO_ID", nullable = false)
+    private Long kakaoId;
 
     @Size(max = 100)
     @NotNull
@@ -83,6 +88,7 @@ public class Member {
         // 값 셋팅
         this.name = userInfo.getNickname();
         this.email = userInfo.getEmail();
+        this.kakaoId = userInfo.getId();
 
         // TODO 임시 값 변경
         this.mediaSeparator = "kakao";

--- a/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.letter.member.repository;
 
 import com.letter.member.entity.InviteOpponent;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,16 +17,29 @@ import static com.letter.question.entity.QQuestion.question;
 public class InviteOpponentCustomRepositoryImpl implements InviteOpponentCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager entityManager;
 
-    public Long findSelectedQuestionIdByLinkKey(String linkKey) {
+    public String findSelectedQuestionIdByLinkKey(String linkKey) {
 
         return jpaQueryFactory
-                .select(selectQuestion.id)
+                .select(question.questionContents)
                 .from(inviteOpponent)
                 .leftJoin(question).on(inviteOpponent.question.id.eq(question.id))
-                .leftJoin(selectQuestion).on(question.id.eq(selectQuestion.question.id))
                 .where(inviteOpponent.linkKey.eq(linkKey))
                 .fetchOne();
+    }
+
+    public Long updateIsShow(String memberId){
+        Long updateIsShow = jpaQueryFactory
+                .update(inviteOpponent)
+                .set(inviteOpponent.isShow, "N")
+                .where(inviteOpponent.member.id.eq(memberId))
+                .execute();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return updateIsShow;
     }
 
 }

--- a/storage/src/main/java/com/letter/member/repository/MemberCustomRepository.java
+++ b/storage/src/main/java/com/letter/member/repository/MemberCustomRepository.java
@@ -1,0 +1,4 @@
+package com.letter.member.repository;
+
+public interface MemberCustomRepository {
+}

--- a/storage/src/main/java/com/letter/member/repository/MemberCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/MemberCustomRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.letter.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.QueryException;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.letter.member.entity.QMember.member;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager entityManager;
+
+    public String findIdByKakaId(Long id) {
+        try{
+            return jpaQueryFactory
+                    .select(member.id)
+                    .from(member)
+                    .where(member.kakaoId.eq(id))
+                    .fetchOne();
+        }
+        catch (QueryException q){
+            log.info("쿼리 실패");
+            return null;
+        }
+    }
+}

--- a/storage/src/main/java/com/letter/member/repository/MemberRepository.java
+++ b/storage/src/main/java/com/letter/member/repository/MemberRepository.java
@@ -9,9 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member,String> {
 
-    // 이메일과 미디어 구분 값으로 디비에 있는 회원 정보 조회
-    Optional<Member> findByAndEmailAndMediaSeparator(String email, String media);
-
     // 총 회원 수 카운트
     long countAllBy();
 }

--- a/storage/src/main/java/com/letter/question/entity/Answer.java
+++ b/storage/src/main/java/com/letter/question/entity/Answer.java
@@ -1,5 +1,6 @@
 package com.letter.question.entity;
 
+import com.letter.member.entity.Couple;
 import com.letter.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -29,6 +30,11 @@ public class Answer {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ANS_ID", nullable = false)
     private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "CP_ID", nullable = false)
+    private Couple couple;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MBR_ID")


### PR DESCRIPTION
## #️⃣연관된 이슈

#90 
#91 
#92 

## 📝작업 내용
- 사용자 조회 커스텀 어노테이션 #90 
  - 커스텀 할 어노테이션의 이름으로 인터페이스 생성
  - resolver 파일 생성
  - WebConfig에 resolver 등록
- 로그인 api 로직 수정 #91 
  - 카카오에서 받은 정보를 가져와서 해당 정보가 우리 디비에 있으면 바로 jwt 토큰을 발급하고 없으면 정보를 디비에 저장하고 jwt 토큰을 받는 로직에서 회원 아이디를 셋팅해주는 부분 수정
  - 카카오 id 추가
- 초대 관련 api 에 사용자 조회 커스텀 어노테이션 추가 및 초대 수락 api 로직 수정 #92
  - 초대 링크 생성 api 와 초대 수락 api에 사용자 조회 커스텀 어노테이션 적용
  - 초대 수락 api
     - 회원 테이블에 커플 아이디 업데이트 하는 로직 추가
     - 초대 상대 테이블의 노출 여부를 "N" 으로 변경하는 로직 추가(+ 관련 엔티티 추가)
     - 답변 등록 시 커플 아이디도 등록되게 로직 추가
  