### PR TITLE
fix: 로그인 redirect_uri 가 서로 다른 경우 발생하는 에러 해결 #96

### DIFF
--- a/domain/src/main/java/com/letter/member/OAuthService.java
+++ b/domain/src/main/java/com/letter/member/OAuthService.java
@@ -101,7 +101,7 @@ public class OAuthService {
             StringBuilder sb = new StringBuilder();
             sb.append("grant_type=authorization_code");
             sb.append("&client_id=8a4726cfed8673405f24582af1d2ff15"); // REST_API_KEY 입력
-            sb.append("&redirect_uri=http://localhost:8080/api/v1/members/kakao/callback"); // 인가코드 받은 redirect_uri 입력
+            sb.append("&redirect_uri=http://localhost:3000/login/kakao"); // 인가코드 받은 redirect_uri 입력
             sb.append("&code=" + code);
             bw.write(sb.toString());
             bw.flush();


### PR DESCRIPTION
## #️⃣연관된 이슈
#96

## 📝작업 내용

- 내 서버로 되어있던 redirect_uri를 클라이언트의 redirect_uri 로 변경