### PR TITLE
refactor: 질문 조회 로직 수정 #112

### DIFF
--- a/domain/src/main/java/com/letter/question/service/AnswerService.java
+++ b/domain/src/main/java/com/letter/question/service/AnswerService.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class AnswerService {
@@ -29,10 +31,12 @@ public class AnswerService {
 
     public ResponseEntity<QuestionContentsResponse> getAnswersQuestion(Long selectedQuestionId, Member member) {
 
-        final Couple couple = coupleCustomRepository.findCoupleInMemberByMemberId(member.getId());
-        if (couple == null) {
+        Optional<Couple> optionalCouple = coupleCustomRepository.findCoupleInMemberByMemberId(member.getId());
+        if (optionalCouple.isEmpty()) {
             throw new CustomException(ErrorCode.COUPLE_NOT_FOUND);
         }
+
+        final Couple couple = optionalCouple.get();
 
         final QuestionContentsResponse questionContentsResponse = questionCustomRepository.findQuestionContentsBySelectQuestionIdAndCouple(selectedQuestionId, couple);
 
@@ -45,10 +49,12 @@ public class AnswerService {
 
     public ResponseEntity<?> registerAnswer(AnswerRequest answerRequest, Member member) {
 
-        final Couple couple = coupleCustomRepository.findCoupleInMemberByMemberId(member.getId());
-        if (couple == null) {
+        Optional<Couple> optionalCouple = coupleCustomRepository.findCoupleInMemberByMemberId(member.getId());
+        if (optionalCouple.isEmpty()) {
             throw new CustomException(ErrorCode.COUPLE_NOT_FOUND);
         }
+
+        final Couple couple = optionalCouple.get();
 
         final SelectQuestion selectQuestion = selectQuestionRepository.findByIdAndCouple(answerRequest.getSelectQuestionId(), couple).orElseThrow(
                 () -> new CustomException(ErrorCode.SELECT_QUESTION_NOT_FOUND)

--- a/storage/src/main/java/com/letter/member/repository/CoupleCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/CoupleCustomRepositoryImpl.java
@@ -8,21 +8,23 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class CoupleCustomRepositoryImpl implements CoupleCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Couple findCoupleInMemberByMemberId(String memberId) {
-        return jpaQueryFactory
+    public Optional<Couple> findCoupleInMemberByMemberId(String memberId) {
+        return Optional.ofNullable(jpaQueryFactory
                 .select(couple)
                 .from(member)
                 .join(couple)
                 .on(member.couple.eq(couple))
                 .where(member.id.eq(memberId),
                         couple.isShow.eq("Y"))
-                .fetchOne();
+                .fetchOne());
     }
 
 }

--- a/storage/src/main/java/com/letter/question/repository/QuestionCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/question/repository/QuestionCustomRepositoryImpl.java
@@ -21,15 +21,27 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    private static final String QUESTION = "question";
+
+    public List<QuestionResponse.QuestionList> findAll() {
+        return jpaQueryFactory
+                .select(Projections.bean(QuestionResponse.QuestionList.class,
+                        question.id.as("questionId"),
+                        question.questionContents.as(QUESTION)))
+                .from(question)
+                .fetch();
+    }
+
     // 질문 리스트 조회
     public List<QuestionResponse.QuestionList> findAllByCouple(Couple couple) {
         return jpaQueryFactory
                 .select(Projections.bean(QuestionResponse.QuestionList.class,
                         question.id.as("questionId"),
-                        question.questionContents.as("question")))
+                        question.questionContents.as(QUESTION)))
                 .from(question)
                 .leftJoin(selectQuestion)
-                .on(selectQuestion.couple.eq(couple), selectQuestion.question.eq(question))
+                .on(selectQuestion.couple.eq(couple),
+                        selectQuestion.question.eq(question))
                 .where(selectQuestion.id.isNull(), question.isShow.eq("Y"))
                 .fetch();
     }
@@ -39,13 +51,14 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
             return jpaQueryFactory
                     .select(Projections.bean(LetterDetailResponse.class,
                             selectQuestion.id.as("selectQuestionId"),
-                            question.questionContents.as("question"),
+                            question.questionContents.as(QUESTION),
                             selectQuestion.createdAt))
                     .from(selectQuestion)
                     .leftJoin(question)
                     .on(selectQuestion.question.id.eq(question.id),
                             question.isShow.eq("Y"))
-                    .where(selectQuestion.couple.eq(couple), selectQuestion.isShow.eq("Y"))
+                    .where(selectQuestion.couple.eq(couple),
+                            selectQuestion.isShow.eq("Y"))
                     .orderBy(selectQuestion.id.desc())
                     .limit(26)
                     .fetch();
@@ -53,13 +66,15 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
             return jpaQueryFactory
                     .select(Projections.bean(LetterDetailResponse.class,
                             selectQuestion.id.as("selectQuestionId"),
-                            question.questionContents.as("question"),
+                            question.questionContents.as(QUESTION),
                             selectQuestion.createdAt))
                     .from(selectQuestion)
                     .leftJoin(question)
                     .on(selectQuestion.question.id.eq(question.id),
                             question.isShow.eq("Y"))
-                    .where(selectQuestion.id.loe(nextCursor), selectQuestion.couple.eq(couple), selectQuestion.isShow.eq("Y"))
+                    .where(selectQuestion.id.loe(nextCursor),
+                            selectQuestion.couple.eq(couple),
+                            selectQuestion.isShow.eq("Y"))
                     .orderBy(selectQuestion.id.desc())
                     .limit(26)
                     .fetch();
@@ -69,7 +84,7 @@ public class QuestionCustomRepositoryImpl implements QuestionCustomRepository {
     public QuestionContentsResponse findQuestionContentsBySelectQuestionIdAndCouple(Long selectQuestionId, Couple couple) {
         return jpaQueryFactory
                 .select(Projections.bean(QuestionContentsResponse.class,
-                        question.questionContents.as("question")))
+                        question.questionContents.as(QUESTION)))
                 .from(selectQuestion)
                 .leftJoin(question)
                 .on(selectQuestion.question.eq(question),


### PR DESCRIPTION
## #️⃣연관된 이슈

#112 

## 📝작업 내용

1. 커플에 아직 속하지 않은 사용자인 경우
    - 모든 프리셋 질문 조회
2. 커플에 속한 사용자인 경우
    - 등록했던 프리셋 질문 제외하고 조회


- 커스텀 쿼리 작성
- 기존 로직에서 분기 처리