### PR TITLE
fix: 초대 링크 생성 api에 커플 관련 유효성 추가 및 초대 수락 api 답변 등록 로직 수정 #115

### DIFF
--- a/storage/src/main/java/com/letter/exception/ErrorCode.java
+++ b/storage/src/main/java/com/letter/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     /* 409 */
     ALREADY_SELECTED_QUESTION(HttpStatus.CONFLICT, "이미 선택했던 질문입니다."),
     ALREADY_ANSWER(HttpStatus.CONFLICT, "질문에 이미 답변을 작성했습니다."),
+    ALREADY_COUPLE(HttpStatus.CONFLICT,"이미 커플이 된 회원입니다."),
 
     /* 401 */
     UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED,"잘못된 JWT 토큰 입니다. 토큰이 비어있을 수 있으니 확인해주세요."),

--- a/storage/src/main/java/com/letter/member/dto/MemberRequest.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberRequest.java
@@ -8,6 +8,8 @@ import com.letter.question.entity.Question;
 import com.letter.question.entity.SelectQuestion;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Data
 public class MemberRequest {
 
@@ -54,13 +56,25 @@ public class MemberRequest {
                     .build();
         }
 
-        public Answer toAnswerInfo(Member member, SelectQuestion selectQuestion, String answer) {
+        public Answer toInvitedPersonAnswerInfo(Member member, SelectQuestion selectQuestion, String answer) {
             return Answer.builder()
                     .member(member)
                     .couple(selectQuestion.getCouple())
                     .selectQuestion(selectQuestion)
                     .answerContents(answer)
                     .isShow("Y")
+                    .createdAt(LocalDateTime.now())
+                    .build();
+        }
+
+        public Answer toInvitePersonAnswerInfo(InviteOpponent inviteOpponent, SelectQuestion selectQuestion) {
+            return Answer.builder()
+                    .member(inviteOpponent.getMember())
+                    .couple(selectQuestion.getCouple())
+                    .selectQuestion(selectQuestion)
+                    .answerContents(inviteOpponent.getAnswer())
+                    .isShow("Y")
+                    .createdAt(inviteOpponent.getCreatedAt())
                     .build();
         }
     }

--- a/storage/src/main/java/com/letter/question/entity/Answer.java
+++ b/storage/src/main/java/com/letter/question/entity/Answer.java
@@ -55,7 +55,6 @@ public class Answer {
     @Column(name = "IS_SHOW", length = 1)
     private String isShow;
 
-    @CreatedDate
     @NotNull
     @Column(name = "CREATED_AT", nullable = false)
     private LocalDateTime createdAt;
@@ -69,5 +68,6 @@ public class Answer {
         this.member = member;
         this.selectQuestion = selectQuestion;
         this.answerContents = answerContents;
+        this.createdAt = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#115 

## 📝작업 내용
- 초대 링크 생성 api에 해당 회원이 커플인지 유효성 체크 로직 추가
- 초대 수락 api 답변 등록 로직에 초대된 사람과 초대한 사람의 답변이 등록되게 수정
- Answer entity 등록일시 @CreatedDate 제거
  - 이유: 초대 수락 api에서 초대한 회원의 답변 등록 시 상대 초대 테이블의 등록일시를 저장하기 위해
- 답변 등록 api > 정보 셋팅하는 부분에 등록일시 셋팅 추가