### PR TITLE
fix: 초대 수락 api 에 유효성 체크 로직 추가 #124

### DIFF
--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -74,7 +74,6 @@ public class MemberService {
                 .build();
     }
 
-
     /**
      * 초대 수락 API
      *
@@ -83,6 +82,20 @@ public class MemberService {
      */
     @Transactional
     public MemberResponse.AcceptInviteLinkResponse acceptedInvite(MemberRequest.AcceptInviteLinkRequest request, Member member) {
+
+        //초대 링크로 들어온 사용자가 커플인지 확인. 커플이면 에러처리
+        if(member.getCouple() != null && member.getCouple().getId() != null){
+            log.error("이미 커플이 된 회원입니다.");
+            throw new CustomException(ErrorCode.ALREADY_COUPLE);
+        }
+
+        //상대 초대 테이블에 노출 여부가 N인 경우 에러처리
+        boolean isExistIsShowN = inviteOpponentCustomRepository.existByMemberIdAndIsShow(member.getId());
+
+        if(isExistIsShowN){
+            log.error("이미 커플이 된 회원이여서 링크 노출 여부가 N 입니다.");
+            throw new CustomException(ErrorCode.ALREADY_COUPLE);
+        }
 
         // 커플 정보 request 셋팅
         // 선택 질문 테이블 등록될 때 자동으로 등록 됨

--- a/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
@@ -42,4 +42,16 @@ public class InviteOpponentCustomRepositoryImpl implements InviteOpponentCustomR
         return updateIsShow;
     }
 
+    /**
+     * 상대 초대 테이블에 노출 여부가 "N" 존재여부 확인
+     * @param memberId
+     * @return
+     */
+    public Boolean existByMemberIdAndIsShow(String memberId){
+        return jpaQueryFactory
+                .selectFrom(inviteOpponent)
+                .where(inviteOpponent.member.id.eq(memberId)
+                        .and(inviteOpponent.isShow.eq("N")))
+                .fetchFirst() != null;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#124 

## 📝작업 내용
- 커플인지 체크 -> 커플이면 에러처리
- 상대 초대 테이블에 노출 여부가 "N" 인 경우 에러처리