### PR TITLE
feat: 초대 링크 생성/초대 수락 api 에 링크 유효시간 체크 로직 추가 #134

### DIFF
--- a/domain/src/main/java/com/letter/exception/ErrorCode.java
+++ b/domain/src/main/java/com/letter/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     ALREADY_COUPLE(HttpStatus.CONFLICT, "C002", "이미 커플이 된 회원입니다."),
     OPPONENT_ALREADY_COUPLE(HttpStatus.CONFLICT, "C003", "상대는 이미 커플이 된 회원입니다."),
     ALREADY_LINK(HttpStatus.CONFLICT,"C004","이미 초대링크가 생성되었습니다."),
-    EXPIRED_LINK(HttpStatus.CONFLICT,"COO5","해당 링크는 유효시간이 만료되었습니다."),
+    EXPIRED_LINK(HttpStatus.CONFLICT,"C005","해당 링크는 유효시간이 만료되었습니다."),
 
     /* Question 관련 Error */
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "프리셋에 존재하지 않는 질문입니다."),

--- a/domain/src/main/java/com/letter/exception/ErrorCode.java
+++ b/domain/src/main/java/com/letter/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     COUPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "커플로 등록되지 않은 사용자입니다."),
     ALREADY_COUPLE(HttpStatus.CONFLICT, "C002", "이미 커플이 된 회원입니다."),
     OPPONENT_ALREADY_COUPLE(HttpStatus.CONFLICT, "C003", "상대는 이미 커플이 된 회원입니다."),
+    ALREADY_LINK(HttpStatus.CONFLICT,"C004","이미 초대링크가 생성되었습니다."),
+    EXPIRED_LINK(HttpStatus.CONFLICT,"COO5","해당 링크는 유효시간이 만료되었습니다."),
 
     /* Question 관련 Error */
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "프리셋에 존재하지 않는 질문입니다."),

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -51,7 +51,14 @@ public class MemberService {
             log.error("이미 커플이 된 회원입니다.");
             throw new CustomException(ErrorCode.ALREADY_COUPLE);
         }
-        // TODO:기존에 보낸 초대 링크가 있다면 초대 링크 키의 유효시간 체크. 링크 키가 생성된지 3일 이내 이면 초대 링크 생성 불가
+
+        // 기존에 보낸 초대 링크가 있다면 초대 링크 키의 유효시간 체크. 링크 키가 생성된지 3일 이내 이면 초대 링크 생성 불가
+        InviteOpponent existLinkData = inviteOpponentCustomRepository.existByMemberIdAndCreatedAt(member.getId());
+
+        if(existLinkData != null){
+            log.error("기존에 생성된 초대링크가 있습니다.");
+            throw new CustomException(ErrorCode.ALREADY_LINK);
+        }
 
         // 링크 고유 키 생성
         String uuid = UUID.randomUUID().toString();
@@ -110,6 +117,14 @@ public class MemberService {
         if(isExistIsShowN){
             log.error("이미 커플이 된 회원이여서 링크 노출 여부가 N 입니다.");
             throw new CustomException(ErrorCode.ALREADY_COUPLE);
+        }
+
+        // 초대 링크 키의 유효시간 체크. 링크 키가 생성된지 1일 이내 이면 초대 수락 불가
+        InviteOpponent existValidLink = inviteOpponentCustomRepository.existByLinkKeyAndCreatedAt(request.getLinkKey());
+
+        if(existValidLink == null){
+            log.error("해당 링크는 유효시간이 만료되었습니다.");
+            throw new CustomException(ErrorCode.EXPIRED_LINK);
         }
 
         // 커플 정보 request 셋팅

--- a/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
@@ -1,10 +1,14 @@
 package com.letter.member.repository;
 
 import com.letter.member.entity.InviteOpponent;
+import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static com.letter.member.entity.QCouple.couple;
 import static com.letter.member.entity.QMember.member;
@@ -53,5 +57,41 @@ public class InviteOpponentCustomRepositoryImpl implements InviteOpponentCustomR
                 .where(inviteOpponent.member.id.eq(memberId)
                         .and(inviteOpponent.isShow.eq("N")))
                 .fetchFirst() != null;
+    }
+
+    /**
+     * 회원 아이디와 등록일자로 데이터가 있는지 확인
+     * @param memberId
+     * @return
+     */
+    public InviteOpponent existByMemberIdAndCreatedAt(String memberId){
+
+        LocalDateTime minutesAgo = LocalDateTime.now().minusDays(1);
+
+        return jpaQueryFactory
+                        .select(inviteOpponent)
+                        .from(inviteOpponent)
+                        .where(inviteOpponent.member.id.eq(memberId)
+                                .and(inviteOpponent.createdAt.after(minutesAgo)))
+                        .orderBy(inviteOpponent.createdAt.desc())
+                        .fetchFirst();
+    }
+
+    /**
+     * 링크 키와 등록일자로 해당 데이터가 있는지 확인
+     * @param linkKey
+     * @return
+     */
+    public InviteOpponent existByLinkKeyAndCreatedAt(String linkKey){
+
+        LocalDateTime minutesAgo = LocalDateTime.now().minusDays(1);
+
+        return jpaQueryFactory
+                .select(inviteOpponent)
+                .from(inviteOpponent)
+                .where(inviteOpponent.linkKey.eq(linkKey)
+                        .and(inviteOpponent.createdAt.after(minutesAgo)))
+                .orderBy(inviteOpponent.createdAt.desc())
+                .fetchFirst();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#134 

## 📝작업 내용

- 초대 링크 생성 api에 링크 생성 유효시간 체크 로직 추가
  - 링크가 생성된지 하루가 지나지 않았으면 에러를 던짐(이미 링크가 생성되었습니다.)
- 초대 수락 api에 링크 생성 유효시간 체크 로직 추가
  - 링크가 유효하지 않은 경우 에러를 던짐(해당 링크는 유효시간이 만료되었습니다.)
