### PR TITLE
feat: 로그인 유저 상태 확인을 위한 API 생성 #145

### DIFF
--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -59,7 +59,7 @@ public class MemberController {
 
     @Operation(summary = "사용자의 상태 확인 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "상태 확인 완료")
+            @ApiResponse(responseCode = "200", description = "상태 확인 완료")
     })
     @LoginCheck
     @GetMapping("/user-status")

--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -4,6 +4,7 @@ import com.letter.annotation.LoginCheck;
 import com.letter.annotation.User;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
+import com.letter.member.dto.MemberStatusResponse;
 import com.letter.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,9 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Invite", description = "초대 관련 API")
+@Tag(name = "Member", description = "사용자 관련 API")
 @RestController
-@RequestMapping("/api/v1/members/invite")
+@RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 @Slf4j
 public class MemberController {
@@ -25,34 +26,44 @@ public class MemberController {
     private final MemberService memberService;
 
     @Operation(summary = "초대 링크 생성 API")
-    @ApiResponses(value ={
-            @ApiResponse(responseCode= "201",description = "초대 링크 키 생성 완료")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "초대 링크 키 생성 완료")
     })
     @LoginCheck
-    @PostMapping("/link")
-    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request, @User Member member){
+    @PostMapping("/invite/link")
+    public ResponseEntity<MemberResponse.CreateInviteLinkResponse> createInviteLink(@RequestBody @Valid MemberRequest.CreateInviteLinkRequest request, @User Member member) {
 
-        return ResponseEntity.ok().body(memberService.createInviteLink(request,member));
+        return ResponseEntity.ok().body(memberService.createInviteLink(request, member));
     }
 
     @Operation(summary = "초대 수락 API")
-    @ApiResponses(value ={
-            @ApiResponse(responseCode= "201",description = "초대 수락 완료")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "초대 수락 완료")
     })
     @LoginCheck
-    @PostMapping("/accept")
-    public ResponseEntity<MemberResponse.AcceptInviteLinkResponse> acceptedInvite(@RequestBody @Valid MemberRequest.AcceptInviteLinkRequest request, @User Member member){
+    @PostMapping("/invite/accept")
+    public ResponseEntity<MemberResponse.AcceptInviteLinkResponse> acceptedInvite(@RequestBody @Valid MemberRequest.AcceptInviteLinkRequest request, @User Member member) {
 
-        return ResponseEntity.ok().body(memberService.acceptedInvite(request,member));
+        return ResponseEntity.ok().body(memberService.acceptedInvite(request, member));
     }
 
     @Operation(summary = "초대 링크로 랜딩되는 페이지 API")
-    @ApiResponses(value ={
-            @ApiResponse(responseCode= "200",description = "정보 가져오기 완료")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정보 가져오기 완료")
     })
-    @GetMapping ("/info/{linkKey}")
-    public ResponseEntity<MemberResponse.InvitedPersonInfoResponse> getInvitedPersonInfo(@PathVariable("linkKey") String linkKey){
+    @GetMapping("/invite/info/{linkKey}")
+    public ResponseEntity<MemberResponse.InvitedPersonInfoResponse> getInvitedPersonInfo(@PathVariable("linkKey") String linkKey) {
 
         return ResponseEntity.ok().body(memberService.getInvitedPersonInfo(linkKey));
+    }
+
+    @Operation(summary = "사용자의 상태 확인 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "상태 확인 완료")
+    })
+    @LoginCheck
+    @GetMapping("/user-status")
+    public ResponseEntity<MemberStatusResponse> getUserStatus(@User Member member) {
+        return ResponseEntity.ok(memberService.getUserStatus(member));
     }
 }

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -2,9 +2,10 @@ package com.letter.member;
 
 import com.letter.exception.CustomException;
 import com.letter.exception.ErrorCode;
-import com.letter.jwt.JwtProvider;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
+import com.letter.member.dto.MemberStatusResponse;
+import com.letter.member.dto.role.UserStatusRole;
 import com.letter.member.entity.Couple;
 import com.letter.member.entity.InviteOpponent;
 import com.letter.member.entity.Member;
@@ -34,9 +35,7 @@ public class MemberService {
     private final AnswerRepository answerRepository;
     private final SelectQuestionRepository selectQuestionRepository;
 
-    private final JwtProvider jwtProvider;
     private final InviteOpponentCustomRepositoryImpl inviteOpponentCustomRepository;
-    private final MemberCustomRepositoryImpl memberCustomRepository;
 
     /**
      * 상대 초대 링크 생성 api
@@ -203,5 +202,20 @@ public class MemberService {
                 .invitedPersonName(name)
                 .question(question)
                 .build();
+    }
+
+
+    public MemberStatusResponse getUserStatus(Member member) {
+        boolean isCouple = member.getCouple() != null;
+        String linkKey = inviteOpponentCustomRepository.getLinkKey(member);
+
+        UserStatusRole userStatus;
+        if (isCouple) {
+            userStatus = UserStatusRole.COUPLE_USER;
+        } else {
+            userStatus = linkKey == null ? UserStatusRole.NON_COUPLE_USER : UserStatusRole.COUPLE_WAITING_USER;
+        }
+
+        return new MemberStatusResponse(userStatus, linkKey);
     }
 }

--- a/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/InviteOpponentCustomRepositoryImpl.java
@@ -1,18 +1,14 @@
 package com.letter.member.repository;
 
 import com.letter.member.entity.InviteOpponent;
-import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.letter.member.entity.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
-import static com.letter.member.entity.QCouple.couple;
-import static com.letter.member.entity.QMember.member;
-import static com.letter.question.entity.QSelectQuestion.selectQuestion;
 import static com.letter.member.entity.QInviteOpponent.inviteOpponent;
 import static com.letter.question.entity.QQuestion.question;
 
@@ -93,5 +89,16 @@ public class InviteOpponentCustomRepositoryImpl implements InviteOpponentCustomR
                         .and(inviteOpponent.createdAt.after(minutesAgo)))
                 .orderBy(inviteOpponent.createdAt.desc())
                 .fetchFirst();
+    }
+
+
+    public String getLinkKey(Member member) {
+        return jpaQueryFactory
+                .select(inviteOpponent.linkKey)
+                .from(inviteOpponent)
+                .where(inviteOpponent.member.eq(member),
+                        inviteOpponent.createdAt.after(LocalDateTime.now().minusDays(1)),
+                        inviteOpponent.isShow.eq("Y"))
+                .fetchOne();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#145 

## 📝작업 내용

- 커플 유무, 유효한 링크키 존재 여부 검사
- `userStatus`라는 역할을 만들어서 Enum으로 유저 상태 관리
- 응답은 `userStatus`, `linkKey`