### PR TITLE
test: save() 후 DB 조회 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ subprojects { // 각 모듈에 적용할 공통 설정
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -174,6 +174,7 @@ public class MemberService {
         // 답변 테이블에 정보 등록
         answerRepository.saveAll(answers);
 
+        // TODO 검사하지 않을 거라면 해당 메서드 반환값을 왜 Long으로 선언했는지, 만약 예외를 던지게 된다면 500 에러가 되어야 할 것 같음
         // 초대 상대 테이블에 노출 여부 'N' 으로 변경
         inviteOpponentCustomRepository.updateIsShow(inviteOpponent.getMember().getId());
 

--- a/storage/src/main/java/com/letter/config/QuerydslConfig.java
+++ b/storage/src/main/java/com/letter/config/QuerydslConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class QuerydslConfig {
+public class QueryDslConfig {
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/storage/src/main/java/com/letter/config/QuerydslConfig.java
+++ b/storage/src/main/java/com/letter/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.letter.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
+++ b/storage/src/main/java/com/letter/member/entity/InviteOpponent.java
@@ -10,12 +10,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
+@DynamicInsert
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -58,5 +60,12 @@ public class InviteOpponent {
     @NotNull
     @Column(name = "CREATED_AT", nullable = false)
     private LocalDateTime createdAt;
+
+    public InviteOpponent(Question question, Member member, String answer, String uuid) {
+        this.question = question;
+        this.member = member;
+        this.answer = answer;
+        this.linkKey = uuid;
+    }
 
 }

--- a/storage/src/test/java/com/letter/TestConfiguration.java
+++ b/storage/src/test/java/com/letter/TestConfiguration.java
@@ -1,0 +1,16 @@
+package com.letter;
+
+import com.letter.security.CryptoHelper;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+@org.springframework.boot.test.context.TestConfiguration
+public class TestConfiguration {
+
+    // "No qualifying bean of type" 에러 발생으로 직접 Bean 등록
+    @Bean
+    public CryptoHelper cryptoHelper() {
+        return new CryptoHelper();
+    }
+}

--- a/storage/src/test/java/com/letter/config/TestQuerydslConfig.java
+++ b/storage/src/test/java/com/letter/config/TestQuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.letter.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@TestConfiguration
+public class TestQuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/storage/src/test/java/com/letter/member/repository/InviteOpponentRepositoryTest.java
+++ b/storage/src/test/java/com/letter/member/repository/InviteOpponentRepositoryTest.java
@@ -1,0 +1,88 @@
+package com.letter.member.repository;
+
+import com.letter.TestConfiguration;
+import com.letter.config.TestQuerydslConfig;
+import com.letter.member.dto.OAuthResponse;
+import com.letter.member.entity.InviteOpponent;
+import com.letter.member.entity.Member;
+import com.letter.question.entity.Question;
+import com.letter.question.repository.QuestionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Repository;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ContextConfiguration(classes = {
+        TestConfiguration.class,
+        TestQuerydslConfig.class
+})
+@DataJpaTest(includeFilters = {
+        @ComponentScan.Filter(
+                type = FilterType.ANNOTATION,
+                classes = Repository.class
+        ) // querydsl 클래스 파일은 CRUDRepository 를 상속받지 않기 때문에 Repository 어노테이션을 추가해도 Component 라서 스캔이 되지 않음 그래서 추가한 설정
+})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class InviteOpponentRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private InviteOpponentRepository inviteOpponentRepository;
+    @Autowired
+    private InviteOpponentCustomRepositoryImpl inviteOpponentCustomRepository;
+
+    @Test
+    @DisplayName("save() 후 DB 조회 테스트")
+    void testSaveLinkKey() {
+        // given
+        final Question question = questionRepository.findQuestionById(1L).orElseThrow();
+
+        final Member member = new Member();
+        member.saveUserInfo(OAuthResponse.builder()
+                        .email("test@test.com")
+                        .id(123456789L)
+                        .nickname("test")
+                        .build(),
+                555L,
+                null);
+        memberRepository.save(member);
+
+        final String uuid = UUID.randomUUID().toString();
+
+        final InviteOpponent inviteOpponent = InviteOpponent.builder()
+                .question(question)
+                .member(member)
+                .answer("몰라")
+                .linkKey(uuid)
+                .build();
+
+        // when
+        inviteOpponentRepository.save(inviteOpponent);
+        final String linkKey = getLinkKey(member);
+
+        // then
+        assertThat(linkKey).isEqualTo(uuid);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+    String getLinkKey(Member member) {
+        return inviteOpponentCustomRepository.getLinkKey(member);
+    }
+
+}


### PR DESCRIPTION
## 📝작업 내용

- 배포된 서비스에서 inviteOpponent 리소스를 생성하고 다른 트랜잭션에서 Querydsl로 조회를 하면 가끔 제대로 조회를 할 수 없는 문제가 발생
- 그래서 해당 테스트 코드를 작성했지만 당장 깊게 들어가서 해결 할 수 있는 시간이 없기 때문에 트랜잭션을 나눠서 테스트하는 것은 다음으로 미루고 JPA, Querydsl 테스트 코드를 완성했다는 것에 의미를 두기로 함
-
- QueryDsl -> Querydsl