### PR TITLE
feat: 질문 현황 페이지 랜더링 관련 API #194

### DIFF
--- a/common/src/main/java/com/letter/member/MemberController.java
+++ b/common/src/main/java/com/letter/member/MemberController.java
@@ -3,6 +3,7 @@ package com.letter.member;
 import com.letter.annotation.LoginCheck;
 import com.letter.annotation.User;
 import com.letter.exception.ExceptionResponse;
+import com.letter.member.dto.MemberCurrentSituationResponse;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
 import com.letter.member.dto.MemberStatusResponse;
@@ -149,6 +150,13 @@ public class MemberController {
     @GetMapping("/user-status")
     public ResponseEntity<MemberStatusResponse> getUserStatus(@User Member member) {
         return ResponseEntity.ok(memberService.getUserStatus(member));
+    }
+
+
+    @LoginCheck
+    @GetMapping("/current-situation")
+    public ResponseEntity<MemberCurrentSituationResponse> getCurrentSituation(@User Member member) {
+        return ResponseEntity.ok(memberService.getCurrentSituation(member));
     }
 
 }

--- a/domain/src/main/java/com/letter/member/MemberService.java
+++ b/domain/src/main/java/com/letter/member/MemberService.java
@@ -2,6 +2,7 @@ package com.letter.member;
 
 import com.letter.exception.CustomException;
 import com.letter.exception.ErrorCode;
+import com.letter.member.dto.MemberCurrentSituationResponse;
 import com.letter.member.dto.MemberRequest;
 import com.letter.member.dto.MemberResponse;
 import com.letter.member.dto.MemberStatusResponse;
@@ -10,17 +11,22 @@ import com.letter.member.entity.Couple;
 import com.letter.member.entity.InviteOpponent;
 import com.letter.member.entity.Member;
 import com.letter.member.repository.*;
+import com.letter.question.dto.LetterDetailDto;
+import com.letter.question.dto.WaitingAnswerSelectQuestionDto;
 import com.letter.question.entity.Answer;
 import com.letter.question.entity.Question;
 import com.letter.question.entity.SelectQuestion;
 import com.letter.question.repository.AnswerRepository;
 import com.letter.question.repository.QuestionRepository;
+import com.letter.question.repository.SelectQuestionCustomRepositoryImpl;
 import com.letter.question.repository.SelectQuestionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 @Service
@@ -34,7 +40,9 @@ public class MemberService {
     private final AnswerRepository answerRepository;
     private final SelectQuestionRepository selectQuestionRepository;
 
+    private final CoupleCustomRepositoryImpl coupleCustomRepository;
     private final InviteOpponentCustomRepositoryImpl inviteOpponentCustomRepository;
+    private final SelectQuestionCustomRepositoryImpl selectQuestionCustomRepository;
 
 
     /**
@@ -225,6 +233,36 @@ public class MemberService {
         }
 
         return new MemberStatusResponse(userStatus, linkKey);
+    }
+
+
+    public MemberCurrentSituationResponse getCurrentSituation(Member member) {
+        final Couple couple = coupleCustomRepository.findCoupleInMemberByMemberId(member.getId()).orElseThrow(
+                () -> new CustomException(ErrorCode.COUPLE_NOT_FOUND)
+        );
+
+        // 공개된 닫힌 질문 조회
+        final List<LetterDetailDto> letterDetailDtoList = selectQuestionCustomRepository.findLockedSelectQuestionByCouple(couple);
+        List<WaitingAnswerSelectQuestionDto> waitingAnswerList = new ArrayList<>();
+        for (LetterDetailDto letterDetailDto : letterDetailDtoList) {
+            String question = letterDetailDto.getQuestion();
+            if (question == null) {
+                question = letterDetailDto.getRegisterQuestion();
+            }
+            waitingAnswerList.add(new WaitingAnswerSelectQuestionDto(
+                    letterDetailDto.getSelectQuestionId(),
+                    question,
+                    letterDetailDto.getCreatedAt()));
+        }
+
+        // 커플 유지 날짜 조회
+        final LocalDateTime startedDateByCoupleId = coupleCustomRepository.findStartedDateByCoupleId(couple.getId());
+        long periodOfUse = ChronoUnit.DAYS.between(startedDateByCoupleId.toLocalDate(), LocalDateTime.now().toLocalDate()) + 1L;
+
+        // 커플이 모두 답변을 등록한 질문 조회
+        final Long countOpenSelectQuestion = selectQuestionCustomRepository.countOpenSelectQuestionByCouple(couple);
+
+        return new MemberCurrentSituationResponse(member.getId(), waitingAnswerList, periodOfUse, countOpenSelectQuestion);
     }
 
 }

--- a/storage/src/main/java/com/letter/member/dto/MemberCurrentSituationResponse.java
+++ b/storage/src/main/java/com/letter/member/dto/MemberCurrentSituationResponse.java
@@ -1,0 +1,16 @@
+package com.letter.member.dto;
+
+import com.letter.question.dto.WaitingAnswerSelectQuestionDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberCurrentSituationResponse {
+    private final String memberId;
+    private final List<WaitingAnswerSelectQuestionDto> waitingAnswerList;
+    private final long periodOfUse;
+    private final long perfectAnswer;
+}

--- a/storage/src/main/java/com/letter/member/repository/CoupleCustomRepositoryImpl.java
+++ b/storage/src/main/java/com/letter/member/repository/CoupleCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static com.letter.member.entity.QCouple.couple;
@@ -25,6 +26,15 @@ public class CoupleCustomRepositoryImpl implements CoupleCustomRepository {
                 .where(member.id.eq(memberId),
                         couple.isShow.eq("Y"))
                 .fetchOne());
+    }
+
+    public LocalDateTime findStartedDateByCoupleId(Long coupleId) {
+        return jpaQueryFactory
+                .select(couple.startedAt)
+                .from(couple)
+                .where(couple.id.eq(coupleId)
+                        .and(couple.isShow.eq("Y")))
+                .fetchOne();
     }
 
 }

--- a/storage/src/main/java/com/letter/question/dto/WaitingAnswerSelectQuestionDto.java
+++ b/storage/src/main/java/com/letter/question/dto/WaitingAnswerSelectQuestionDto.java
@@ -1,0 +1,14 @@
+package com.letter.question.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class WaitingAnswerSelectQuestionDto {
+    private final long selectQuestionId;
+    private final String question;
+    private final LocalDateTime createdAt;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#194 

## 📝작업 내용

- DTO 클래스 생성
- 노출여부 'Y'인 닫혀있는 질문 조회
- 커플을 유지한 기간 조회
- 둘 다 답한 질문 개수 조회

- Count 조회 할 때 중복 제거가 되지 않아서 `count(distinct selectQuestion)` 조회